### PR TITLE
Xelatex a lualatex

### DIFF
--- a/betterposter.cls
+++ b/betterposter.cls
@@ -24,10 +24,18 @@
 %% Remove default margins
 \geometry{margin=0in}
 
+\RequirePackage{ifxetex}
+
 %% Font
+\ifxetex
+\RequirePackage{cmbright}
+\RequirePackage[no-math]{fontspec}
+\setmainfont{Lato}
+\else
 \RequirePackage{cmbright}
 \RequirePackage[default]{lato}
 \RequirePackage[T1]{fontenc}
+\fi
 
 %% Small separation on enumerate and itemize
 \RequirePackage{enumitem}

--- a/betterposter.cls
+++ b/betterposter.cls
@@ -25,9 +25,15 @@
 \geometry{margin=0in}
 
 \RequirePackage{ifxetex}
+\RequirePackage{ifluatex}
+
+\newif\ifxetexorluatex
+\ifxetex\xetexorluatextrue\else
+\ifluatex\xetexorluatextrue\else
+\xetexorluatexfalse\fi\fi
 
 %% Font
-\ifxetex
+\ifxetexorluatex
 \RequirePackage{cmbright}
 \RequirePackage[no-math]{fontspec}
 \setmainfont{Lato}

--- a/main.tex
+++ b/main.tex
@@ -34,6 +34,8 @@
 \\translated into \textbf{plain English}.
 \\\textbf{Emphasize} the important!
 
+Příliš žluťoučký kůň úpěl ďábelské ó.
+
 
 %%%%%%%% MAIN COLUMN END
 }{


### PR DESCRIPTION
Umožňuje použít xelatex/lualatex. Výsledný dokument vypadá trochu jinak než z pdflatexu, ale diakritika funguje.

Další možnosti:

- volat `\RequirePackage[default]{lato}` místo `setmainfont`,
- zkusit vymyslet jak líp nastavit `setmainfont` tak, aby se výstup víc blížil původnímu.

Má-li k tomu někdo nějaký názor/nápad, uvítám diskusi, jinak bych mergnul aspoň tohle.